### PR TITLE
Remove zipkin js, replace with custom solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "seneca": "^3.0.0",
-    "zipkin": "^0.2.6",
-    "zipkin-transport-http": "^0.2.6"
+    "request": "^2.74.0",
+    "seneca": "^3.0.0"
   }
 }

--- a/tracer/index.js
+++ b/tracer/index.js
@@ -1,25 +1,5 @@
 
-var zipkin = require('zipkin');
-var Tracer = zipkin.Tracer
-var TraceId = zipkin.TraceId
-var BatchRecorder = zipkin.BatchRecorder
-var ConsoleRecorder = zipkin.ConsoleRecorder
-var ExplicitContext = zipkin.ExplicitContext
-var Annotation = zipkin.Annotation
-var Some = zipkin.option.Some
-var None = zipkin.option.None
-
-var HttpLogger = require('zipkin-transport-http').HttpLogger;
-
-var zipkinBaseUrl = 'http://127.0.0.1:9411';
-var recorder = new BatchRecorder({
-  logger: new HttpLogger({
-    endpoint: `${zipkinBaseUrl}/api/v1/spans`
-  })
-});
-// recorder = new ConsoleRecorder()
-var ctxImpl = new ExplicitContext();
-var tracer = new Tracer({ctxImpl, recorder});
+var tracer = require('../zipkin');
 
 function tracerPlugin(options) {
   var seneca = this;
@@ -35,100 +15,40 @@ function tracerPlugin(options) {
   })
 
   function handle_as_client(context, pin, msg, done) {
-    tracer.scoped(function () {
+    var trace_data = tracer.get_child(context.fixedargs.tracer)
+    tracer.client_send(trace_data, {
+      service: service,
+      name: pin
+    })
 
-      var id = get_trace_id_for_child(context.fixedargs.tracer)
-      tracer.setId(id)
-      tracer.recordServiceName(service);
-      tracer.recordRpc(pin);
-      tracer.recordAnnotation(new Annotation.ClientSend())
+    context.fixedargs.tracer = trace_data
 
-      // msg.tracer = {
-      //   traceId: id.traceId,
-      //   spanId: id.spanId,
-      //   parentId: id.parentId,
-      //   sampled: id.sampled
-      // }
-
-      console.log('\n\nhandle_as_client\npin', pin, '\nOriginal', context.fixedargs.tracer, '\nNew', id)
-
-      msg.tracer = context.fixedargs.tracer = {
-        traceId: id.traceId,
-        currentSpanId: id.spanId,
-        parentId: id.parentId,
-        sampled: id.sampled.value
-      }
-
-      context.prior(msg, function (err, msg) {
-        tracer.scoped(function () {
-          tracer.setId(id);
-          tracer.recordServiceName(service);
-          tracer.recordRpc(pin);
-          tracer.recordAnnotation(new Annotation.ClientRecv())
-
-          done(err, msg)
-        })
+    context.prior(msg, function (err, msg) {
+      tracer.client_recv(trace_data, {
+        service: service,
+        name: pin
       })
+
+      done(err, msg)
     })
   }
 
   function handle_as_server(context, pin, msg, done) {
-    tracer.scoped(function () {
+    var trace_data = tracer.get_data(msg.tracer)
+    tracer.server_recv(trace_data, {
+      service: service,
+      name: pin
+    })
 
-      var id = get_trace_id(msg.tracer)
-      tracer.setId(id)
-      tracer.recordServiceName(service);
-      tracer.recordRpc(pin);
-      tracer.recordAnnotation(new Annotation.ServerRecv())
+    msg.tracer = context.fixedargs.tracer = trace_data
 
-      console.log('\n\nhandle as server\npin', pin, '\nOriginal', msg.tracer, '\nNew', id)
-
-      msg.tracer = context.fixedargs.tracer = {
-        traceId: id.traceId,
-        parentId: id.parentId,
-        currentSpanId: id.spanId,
-        sampled: id.sampled.value
-      }
-
-      context.prior(msg, function (err, msg) {
-        tracer.scoped(function () {
-          tracer.setId(id);
-          tracer.recordServiceName(service);
-          tracer.recordRpc(pin);
-          tracer.recordAnnotation(new Annotation.ServerSend())
-
-          done(err, msg)
-        })
+    context.prior(msg, function (err, msg) {
+      tracer.server_send(trace_data, {
+        service: service,
+        name: pin
       })
 
-    })
-  }
-
-  function get_trace_id_for_child(data) {
-    if (!data) {
-      return tracer.createRootId({sampled: true})
-    }
-
-    tracer.setId(new TraceId ({
-      traceId: new Some(data.traceId),
-      parentId: data.parentId ? new Some(data.parentId) : None,
-      spanId: data.currentSpanId,
-      sampled: new Some(data.sampled)
-    }))
-
-    return tracer.createChildId()
-  }
-
-  function get_trace_id(data) {
-    if (!data) {
-      return tracer.createRootId({sampled: true})
-    }
-
-    return new TraceId({
-      traceId: new Some(data.traceId),
-      spanId: data.currentSpanId,
-      parentId: new Some(data.parentId),
-      sampled: new Some(data.sampled)
+      done(err, msg)
     })
   }
 }

--- a/zipkin/index.js
+++ b/zipkin/index.js
@@ -1,0 +1,139 @@
+
+var request = require('request')
+var zipkinBaseUrl = 'http://127.0.0.1:9411'
+var PATH = `${zipkinBaseUrl}/api/v1/spans`
+
+function send (body) {
+  // console.log('sending', JSON.stringify(body, null, 4))
+
+  request({
+    url: PATH,
+    method: 'POST',
+    json: true,
+    body: [body]
+  }, function sent (err, response, body) {
+    if (err) {
+      return console.log('An error occurred sending trace data', err)
+    }
+
+    if (response.statusCode != 200 && response.statusCode != 202) {
+      return console.log('Server returned an error:', response.statusCode, '\n', body)
+    }
+  })
+}
+
+function generate_timestamp() {
+  // use process.hrtime?
+  return new Date().getTime() * 1000
+}
+
+function generate_id () {
+  // copied over from zipkin-js
+  var digits = '0123456789abcdef';
+  var n = '';
+  for (var i = 0; i < 16; i++) {
+    var rand = Math.floor(Math.random() * 16);
+
+    // avoid leading zeroes
+    if (rand !== 0 || n.length > 0) {
+      n += digits[rand];
+    }
+  }
+  return n;
+}
+
+function create_root_trace () {
+  var id = generate_id()
+
+  return {
+    trace_id: id,
+    span_id: id,
+    parent_id: null,
+    sampled: true,
+    timestamp: generate_timestamp()
+  }
+}
+
+function get_data (trace_data) {
+  if (!trace_data) {
+    return create_root_trace()
+  }
+
+  return trace_data
+}
+
+function get_child (trace_data) {
+  if (!trace_data) {
+    return create_root_trace()
+  }
+
+  return {
+    trace_id: trace_data.trace_id,
+    parent_span_id: trace_data.span_id,
+    span_id: generate_id(),
+    sample: true,
+    timestamp: generate_timestamp()
+  }
+}
+
+function send_trace (trace, data) {
+  var time = generate_timestamp()
+  var body = {
+    traceId: trace.trace_id,
+    name: data.name,
+    id: trace.span_id,
+    timestamp: trace.timestamp,
+    annotations: [],
+    binaryAnnotations: []
+  }
+
+  if (trace.parent_span_id) {
+    body.parentId = trace.parent_span_id
+  }
+
+  for (var i = 0; i < data.annotations.length; i++) {
+    body.annotations.push({
+      endpoint: {
+        serviceName: data.service,
+        ipv4: 0,
+        port: 0
+      },
+      timestamp: time,
+      value: data.annotations[i]
+    })
+  }
+
+  send(body)
+}
+
+function trace_with_annotation (trace, data, annotation) {
+  data.annotations = data.annotations || []
+  data.annotations.push(annotation)
+  return send_trace(trace, data)
+}
+
+function client_send (trace, data) {
+  return trace_with_annotation(trace, data, 'cs')
+}
+
+function client_recv (trace, data) {
+  return trace_with_annotation(trace, data, 'cr')
+}
+
+function server_send (trace, data) {
+  return trace_with_annotation(trace, data, 'ss')
+}
+
+function server_recv (trace, data) {
+  return trace_with_annotation(trace, data, 'sr')
+}
+
+
+module.exports = {
+  get_data: get_data,
+  get_child: get_child,
+  client_send: client_send,
+  client_recv: client_recv,
+  server_send: server_send,
+  server_recv: server_recv
+}


### PR DESCRIPTION
Custom solution is very basic, and has this major issues
- sends a request for each annotation (could be batched to reduce the
  traffic)
- doesn't support sampling (all traces are collected)
- doesn't support binary annotations
- only support http transport to send data to zipkin
