### PR TITLE
Add auto-discovery of actions to override

### DIFF
--- a/client.js
+++ b/client.js
@@ -6,15 +6,15 @@ var tracer = require('./tracer')
 seneca({
   tag: 'client1'
 })
+.use(tracer)
 .client({
   type:'http',
   port:3000,
   pin: 'a:1'
 })
-.use(tracer, {
-  pins: ['a:1']
+.ready(function () {
+  this.act('a:1', function (err, msg) {
+    console.log(err, msg)
+    setTimeout(process.exit, 2000)
+  });
 })
-.act('a:1', function (err, msg) {
-  console.log(err, msg)
-  setTimeout(process.exit, 2000)
-});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "async": "^2.0.1",
     "request": "^2.74.0",
     "seneca": "^3.0.0"
   }

--- a/service1.js
+++ b/service1.js
@@ -6,6 +6,7 @@ var tracer = require('./tracer')
 seneca({
   tag: 'service1'
 })
+.use(tracer)
 .client({
   type:'http',
   port:3001,
@@ -17,10 +18,4 @@ seneca({
 })
 .add('a:1', function (msg, done) {
   this.act('b:1', done)
-})
-.use(tracer, {
-  pins: [
-    'a:1',
-    'b:1'
-  ]
 })

--- a/service2.js
+++ b/service2.js
@@ -1,9 +1,11 @@
 var seneca = require('seneca')
+var async = require('async')
 var tracer = require('./tracer')
 
 seneca({
   tag: 'service2'
 })
+.use(tracer)
 .client({
   type:'http',
   port:3002,
@@ -13,12 +15,20 @@ seneca({
   type:'http',
   port:3001
 })
-.add('b:1', function (msg, done) {
-  this.act('c:1', done)
+.add('internal:1', function (msg, done) {
+  var seneca = this
+  async.parallel({
+    result: function (next) { seneca.act('c:1', next) },
+    fake: function (next) { seneca.act('internal:2', next) }
+  }, function (err, res) {
+    done(err,res && res.result)
+  })
 })
-.use(tracer, {
-  pins: [
-    'b:1',
-    'c:1'
-  ]
+.add('internal:2', function (msg, done) {
+  process.nextTick(function () {
+    done()
+  })
+})
+.add('b:1', function (msg, done) {
+  this.act('internal:1', done)
 })

--- a/service3.js
+++ b/service3.js
@@ -4,13 +4,11 @@ var tracer = require('./tracer')
 seneca({
   tag: 'service3'
 })
+.use(tracer)
 .listen({
   type:'http',
   port:3002
 })
 .add('c:1', function (msg, done) {
   done(null, {hello:'world'})
-})
-.use(tracer, {
-  pins: ['c:1']
 })

--- a/tracer/index.js
+++ b/tracer/index.js
@@ -1,56 +1,93 @@
 
 var tracer = require('../zipkin');
 
-function tracerPlugin(options) {
-  var seneca = this;
-  var service = seneca.private$.optioner.get().tag;
+function handler(msg, done) {
+  var pin = msg.meta$.pattern
+  if (msg.transport$)
+    return handle_as_server(this, pin, msg, done)
 
-  options.pins.forEach(function register (pin) {
-    seneca.add(pin, function (msg, done) {
-      if (msg.transport$)
-        return handle_as_server(this, pin, msg, done)
+  handle_as_client(this, pin, msg, done)
+}
 
-      handle_as_client(this, pin, msg, done)
-    })
+function wrap_add(seneca) {
+  var root = seneca;
+  var api_add = root.add;
+  root.add = function (pattern, cb, data) {
+    api_add.apply(this, arguments)
+    api_add.call(seneca, pattern, handler)
+  }
+}
+
+function internal_action(action) {
+  return  action.match.role === 'seneca' || action.match.role === 'transport' || action.match.role === 'options'
+}
+
+function override_actions(seneca) {
+  var actions = seneca.private$.actrouter.list()
+  for (var i = 0; i < actions.length; i++) {
+    var action = actions[i]
+
+    if (!internal_action(action)) {
+      seneca.add(action.match, handler)
+    }
+  }
+}
+
+function handle_as_client(context, pin, msg, done) {
+  var service = context.private$.optioner.get().tag
+  var trace_data = tracer.get_child(context.fixedargs.tracer)
+  tracer.client_send(trace_data, {
+    service: service,
+    name: pin
   })
 
-  function handle_as_client(context, pin, msg, done) {
-    var trace_data = tracer.get_child(context.fixedargs.tracer)
-    tracer.client_send(trace_data, {
+  context.fixedargs.tracer = trace_data
+
+  context.prior(msg, function (err, msg) {
+    tracer.client_recv(trace_data, {
       service: service,
       name: pin
     })
 
-    context.fixedargs.tracer = trace_data
+    done(err, msg)
+  })
+}
 
-    context.prior(msg, function (err, msg) {
-      tracer.client_recv(trace_data, {
-        service: service,
-        name: pin
-      })
+function handle_as_server(context, pin, msg, done) {
+  var service = context.private$.optioner.get().tag
+  var trace_data = tracer.get_data(msg.tracer)
+  tracer.server_recv(trace_data, {
+    service: service,
+    name: pin
+  })
 
-      done(err, msg)
-    })
-  }
+  msg.tracer = context.fixedargs.tracer = trace_data
 
-  function handle_as_server(context, pin, msg, done) {
-    var trace_data = tracer.get_data(msg.tracer)
-    tracer.server_recv(trace_data, {
+  context.prior(msg, function (err, msg) {
+    tracer.server_send(trace_data, {
       service: service,
       name: pin
     })
 
-    msg.tracer = context.fixedargs.tracer = trace_data
+    done(err, msg)
+  })
+}
 
-    context.prior(msg, function (err, msg) {
-      tracer.server_send(trace_data, {
-        service: service,
-        name: pin
-      })
+function tracerPlugin(options) {
+  var seneca = this
 
-      done(err, msg)
-    })
-  }
+  override_actions(seneca)
+  wrap_add(seneca)
+
+  // options.pins.forEach(function register (pin) {
+  //   seneca.add(pin, function (msg, done) {
+  //     if (msg.transport$)
+  //       return handle_as_server(this, pin, msg, done)
+
+  //     handle_as_client(this, pin, msg, done)
+  //   })
+  // })
+
 }
 
 module.exports = tracerPlugin


### PR DESCRIPTION
Also start to track local actions and expand service2 to make the trace tree a bit more complex

This work in two steps:
- override existing actions at the moment of plugin initialisation
- override seneca.add so that newly added actions can be overridden at runtime

Issues/thinks to check
- overriding seneca.add is a fragile hack. Need to check it doesn't disrupt actions created through plugins etc
- if a "tracked" action is overridden by the final dev and it uses prior, the action will be tracked twice (first time the new action will be tracked, second time the "original tracked" one)
- tracking all actions without sending batch requests to pipkin could cause a measurable performance penalty
- I'm currently filtering seneca internal actions, but probably the filter isn't complete
